### PR TITLE
Add support for Silverstripe 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Translations were pulled from SilverStripe CMS v3.0.2 (before the `SiteTree.META
 
 ## Requirements:
 
-This module requires SilverStripe Framework & CMS version 4 and up:
+This module requires SilverStripe Framework & CMS version 5 and up:
 
-- `"silverstripe/cms": "^4"`
-- `"silverstripe/framework": "^4"`
+- `"silverstripe/cms": "^5"`
+- `"silverstripe/framework": "^5"`
 
 For a SilverStripe 3 compatible version, please use the 1.x line of releases (with composer, require version `^1.0`).
 
@@ -26,7 +26,7 @@ Installation with Composer is preferred, but not required. Both methods of insta
 #### Composer
 
 ```bash
-$ composer require kinglozzer/metatitle:^2.0
+$ composer require kinglozzer/metatitle:^3.0
 ```
 
 #### ZIP Download

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,11 @@
         "issues": "https://github.com/kinglozzer/silverstripe-metatitle/issues"
     },
     "require": {
-        "silverstripe/cms": "^4"
+        "php": "^8.1",
+        "silverstripe/cms": "^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/MetaTitleExtension.php
+++ b/src/MetaTitleExtension.php
@@ -12,25 +12,17 @@ use SilverStripe\View\ArrayData;
 use SilverStripe\View\HTML;
 use SilverStripe\View\SSViewer;
 
+/**
+ * @property string $MetaTitle
+ */
 class MetaTitleExtension extends DataExtension
 {
-    /**
-     * @config
-     * @var array
-     */
-    private static $db = [
+    private static array $db = [
         'MetaTitle' => 'Varchar(255)'
     ];
 
-    /**
-     * @config
-     * @var string
-     */
-    private static $title_format = '$MetaTitle &raquo; $SiteConfig.Title';
+    private static string $title_format = '$MetaTitle &raquo; $SiteConfig.Title';
 
-    /**
-     * @param FieldList $fields
-     */
     public function updateCMSFields(FieldList $fields)
     {
         if ($this->owner instanceof RedirectorPage || $this->owner instanceof VirtualPage) {
@@ -44,7 +36,7 @@ class MetaTitleExtension extends DataExtension
             ))
             ->addExtraClass('help');
 
-        $fields->insertBefore($metaFieldTitle, 'MetaDescription');
+        $fields->insertBefore('MetaDescription', $metaFieldTitle);
     }
 
     /**

--- a/tests/MetaTitleExtensionTest.php
+++ b/tests/MetaTitleExtensionTest.php
@@ -8,26 +8,23 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Dev\TestOnly;
-use SilverStripe\ORM\DataObject;
+use SilverStripe\i18n\i18n;
 use SilverStripe\i18n\Messages\MessageProvider;
 use SilverStripe\i18n\Messages\Symfony\ModuleYamlLoader;
 use SilverStripe\i18n\Messages\Symfony\SymfonyMessageProvider;
 use SilverStripe\i18n\Messages\YamlReader;
-use SilverStripe\i18n\i18n;
+use SilverStripe\ORM\DataObject;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Translator;
 
 class MetaTitleExtensionTest extends SapphireTest
 {
-    /**
-     * @var array
-     */
+
     public static $extra_dataobjects = [
         MetaTitleExtensionTest_DataObject::class
     ];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -47,14 +44,14 @@ class MetaTitleExtensionTest extends SapphireTest
         Injector::inst()->registerService($provider, MessageProvider::class);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         i18n::set_locale($this->originalLocale);
 
         parent::tearDown();
     }
 
-    public function testUpdateCMSFields()
+    public function testUpdateCMSFields(): void
     {
         // Add custom translation for testing
         $provider = Injector::inst()->get(MessageProvider::class);
@@ -71,7 +68,7 @@ class MetaTitleExtensionTest extends SapphireTest
         $this->assertEquals('TRANS-EN Meta Title Help', $metaTitleField->RightTitle());
     }
 
-    public function testUpdateFieldLabels()
+    public function testUpdateFieldLabels(): void
     {
         // Add custom translation for testing
         $provider = Injector::inst()->get(MessageProvider::class);
@@ -98,7 +95,7 @@ class MetaTitleExtensionTest extends SapphireTest
         $this->assertEquals('TRANS-DE Meta Title', $page->fieldLabel('MetaTitle'));
     }
 
-    public function testDataIntegrity()
+    public function testDataIntegrity(): void
     {
         $page = new Page();
         $page->MetaTitle = 'Custom meta title';
@@ -115,10 +112,10 @@ class MetaTitleExtensionTest extends SapphireTest
         $this->assertEquals('Custom DO meta title', $objTest->MetaTitle);
     }
 
-    public function testMetaTags()
+    public function testMetaTags(): void
     {
         $format = '$MetaTitle - Site Name';
-        Config::inst()->update(MetaTitleExtension::class, 'title_format', $format);
+        Config::modify()->set(MetaTitleExtension::class, 'title_format', $format);
 
         $page = new Page();
         $page->Title = 'Page title';
@@ -134,18 +131,4 @@ class MetaTitleExtensionTest extends SapphireTest
         $this->assertEquals(1, $result, 'Meta title tag not found');
         $this->assertEquals('Page meta title - Site Name', $matches[1], 'Meta title incorrect');
     }
-}
-
-class MetaTitleExtensionTest_DataObject extends DataObject implements TestOnly
-{
-    private static $db = [
-        'MetaDescription' => 'Text',
-        'URLSegment' => 'Varchar(100)'
-    ];
-
-    private static $extensions = [
-        MetaTitleExtension::class
-    ];
-
-    private static $table_name = 'metatitleextensiontest_dataobject';
 }

--- a/tests/MetaTitleExtensionTest_DataObject.php
+++ b/tests/MetaTitleExtensionTest_DataObject.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Kinglozzer\SilverStripeMetaTitle\Tests;
+
+use Kinglozzer\SilverStripeMetaTitle\MetaTitleExtension;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class MetaTitleExtensionTest_DataObject extends DataObject implements TestOnly
+{
+    private static $db = [
+        'MetaDescription' => 'Text',
+        'URLSegment' => 'Varchar(100)'
+    ];
+
+    private static $extensions = [
+        MetaTitleExtension::class
+    ];
+
+    private static $table_name = 'metatitleextensiontest_dataobject';
+}


### PR DESCRIPTION
## Breaking

Given that Silverstripe 5 changes the order of properties being supplies to `insertBefore()`, I'm guessing we won't/can't support `4` and `5` at the same time? So I'm guessing this will need to be a new MAJOR.

## Composer requirements

* Matching minimum PHP requirements of Silverstripe 5
* Updated PHP Unit to `9.5`

## `MetaTitleExtension` changes

* Silverstripe 5 changed the order of properties for `insertBefore()`.
* Added property docblock
* Add property types

## `MetaTitleExtensionTest` changes

* Split `DataObject` into a separate file
* Minor change to how we update config